### PR TITLE
Update run method to be threaded

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -25,6 +25,7 @@ impl Application {
     }
 }
 
+#[derive(Debug)]
 pub struct Status {
     pub name: String,
     pub version: String,

--- a/src/container.rs
+++ b/src/container.rs
@@ -6,6 +6,7 @@ pub struct Container {
     pub apps: Vec<String>,
 }
 
+#[derive(Debug)]
 pub struct Status {
     pub name: String,
     pub apps: Vec<crate::application::Status>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::error::Error;
 use std::fs;
+use std::sync::{Arc, Mutex};
+use std::thread;
 
 pub mod application;
 pub mod container;
@@ -24,41 +26,58 @@ impl Config {
 }
 
 pub fn run(config: Config) -> Result<Vec<container::Status>, Box<dyn Error>> {
-    let mut data = vec![];
+    let data = Arc::new(Mutex::new(vec![]));
+    let applications = Arc::new(Mutex::new(config.applications));
+    let mut handles = vec![];
 
-    for (name, container) in config.containers.iter() {
-        let mut container_status = container::Status::new(name.to_string());
-        let mut apps = container.apps.clone();
-        apps.sort();
+    for (name, container) in config.containers.into_iter() {
+        handles.push(thread::spawn({
+            let mut apps = container.apps.clone();
+            let mut container_status = container::Status::new(name.to_string());
 
-        docker::run(name, &container.path).expect("Unable to start docker container");
+            let container_path = container.path.clone();
+            let data = Arc::clone(&data);
+            let applications = Arc::clone(&applications);
 
-        for app_name in apps.iter() {
-            let app = config.applications.get(app_name).unwrap();
-            let output = docker::execute(name, &app.version_command);
-            let version = app.query_version(&output).unwrap();
+            apps.sort();
 
-            let eol_status: String = match &app.eol {
-                Some(x) => {
-                    let status: String = x.query(&version).unwrap().into();
-                    format!("(eol: {status})")
+            move || {
+                docker::run(&name, &container_path).expect("Unable to start docker container");
+
+                for app_name in apps.iter() {
+                    let applications = applications.lock().unwrap();
+                    let app = applications.get(app_name).unwrap();
+                    let output = docker::execute(&name, &app.version_command);
+                    let version = app.query_version(&output).unwrap();
+
+                    let eol_status: String = match &app.eol {
+                        Some(x) => {
+                            let status: String = x.query(&version).unwrap().into();
+                            format!("(eol: {status})")
+                        }
+                        _ => String::from(""),
+                    };
+
+                    container_status.apps.push(application::Status {
+                        name: app_name.to_string(),
+                        version,
+                        eol_status: Some(eol_status),
+                    });
                 }
-                _ => String::from(""),
-            };
 
-            container_status.apps.push(application::Status {
-                name: app_name.to_string(),
-                version,
-                eol_status: Some(eol_status),
-            });
-        }
+                docker::stop(&name).expect("Unable to clean up docker container");
 
-        docker::stop(name).expect("Unable to clean up docker container");
-
-        data.push(container_status);
+                let mut data = data.lock().unwrap();
+                data.push(container_status);
+            }
+        }));
     }
 
-    Ok(data)
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    Ok(*data.lock().unwrap())
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,9 @@ pub fn run(config: Config) -> Result<Vec<container::Status>, Box<dyn Error>> {
         h.join().unwrap();
     }
 
-    Ok(*data.lock().unwrap())
+    let data = Arc::try_unwrap(data);
+
+    Ok(data.unwrap().into_inner().unwrap())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Reimplement `corrator::run` to use threads. This can fairly dramatically reduce execution time.